### PR TITLE
fix(a11y): remove redundant `aria-roles`

### DIFF
--- a/src/components/ColourPicker.tsx
+++ b/src/components/ColourPicker.tsx
@@ -128,7 +128,6 @@ const ColourPicker = ({
                 "p-4 sm:p-5",
                 "shadow-sm",
             ].join(" ")}
-            role="region"
             aria-label="Background and text colour pickers"
         >
             <header className="flex items-center justify-between">

--- a/src/components/ContrastChecker.tsx
+++ b/src/components/ContrastChecker.tsx
@@ -53,7 +53,6 @@ export default function ContrastChecker({
                 "shadow-sm",
             ].join(" ")}
             aria-labelledby="contrast-heading"
-            role="group"
         >
             <header className="flex items-center justify-between">
                 <h3
@@ -77,13 +76,11 @@ export default function ContrastChecker({
             {/* Results list */}
             <dl
                 className="grid grid-cols-1 gap-x-6 gap-y-3"
-                role="list"
             >
                 {results.map(({ label, passed }) => (
                     <div
                         key={label}
                         className="flex items-center justify-between rounded-lg border border-slate-200 bg-white/50 px-3 py-2 dark:border-slate-700 dark:bg-slate-800/50"
-                        role="listitem"
                     >
                         <dt className="text-sm font-medium text-slate-800 dark:text-slate-200">
                             {label}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -49,7 +49,6 @@ export default function Footer() {
         <footer
             id="footer"
             className="border-t border-slate-200 py-10 text-center text-slate-600 dark:border-slate-800 dark:text-slate-400"
-            role="contentinfo"
         >
             <div className="mx-auto flex max-w-6xl flex-col items-center justify-between px-6 md:flex-row">
                 <p className="text-sm" aria-label="Copyright notice">

--- a/src/components/LivePreview.tsx
+++ b/src/components/LivePreview.tsx
@@ -29,7 +29,6 @@ export default function LivePreview({
                 "p-4 sm:p-5",
                 "shadow-sm",
             ].join(" ")}
-            role="region"
             aria-label="Live preview"
         >
             <header className="flex flex-col gap-2">
@@ -70,7 +69,6 @@ export default function LivePreview({
                     "shadow-sm",
                 ].join(" ")}
                 style={{ backgroundColor: backgroundHex, color: textHex }}
-                role="img"
                 aria-label={`Preview area with text colour ${textHex} on background ${backgroundHex}`}
             >
                 <p className="text-xl font-semibold tracking-tight sm:text-2xl">


### PR DESCRIPTION
remove redundant `aria-roles` on semantic elements:

- `section`
- `dl`
- `div`
- `footer`