### PR TITLE
refactor: omit `aria-invalid` when input is valid

### DIFF
--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -62,7 +62,7 @@ const ColorInput = ({
                     id={id}
                     type="text"
                     inputMode="text"
-                    aria-invalid={!isValid}
+                    aria-invalid={!isValid || undefined}
                     aria-describedby={!isValid ? `${id}-error` : `${id}-hint`}
                     value={value}
                     onChange={(e) => onChange(e.target.value)}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -66,7 +66,7 @@ export default function ThemeToggle() {
         <button
             type="button"
             onClick={toggle}
-            aria-pressed={isDark}
+            aria-pressed={isDark ? true : false}
             aria-label={label}
             title={label}
             className={[


### PR DESCRIPTION
explicitly return `true` or `false` for `button` > `aria-pressed`