### PR TITLE
fix(a11y): improve accessibility audit results

### DIFF
--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -130,9 +130,9 @@ const ColorPicker = ({
             aria-label="Background and text color pickers"
         >
             <header className="flex items-center justify-between">
-                <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+                <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
                     Colors
-                </h3>
+                </h2>
             </header>
 
             <div className="flex flex-col gap-4">

--- a/src/components/ContrastChecker.tsx
+++ b/src/components/ContrastChecker.tsx
@@ -49,12 +49,12 @@ export default function ContrastChecker({
             aria-labelledby="contrast-heading"
         >
             <header className="flex items-center justify-between">
-                <h3
+                <h2
                     id="contrast-heading"
                     className="text-lg font-semibold text-slate-900 dark:text-slate-100"
                 >
                     Results
-                </h3>
+                </h2>
 
                 {/* Prominent ratio display */}
                 <div

--- a/src/components/LivePreview.tsx
+++ b/src/components/LivePreview.tsx
@@ -32,9 +32,9 @@ export default function LivePreview({
             aria-label="Live preview"
         >
             <header className="flex flex-col gap-2">
-                <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+                <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
                     Live Preview
-                </h3>
+                </h2>
 
                 {/* Current colors (for quick reference) */}
                 <div className="flex flex-wrap items-center gap-x-5 gap-y-1 text-sm text-slate-700 dark:text-slate-300">
@@ -69,11 +69,10 @@ export default function LivePreview({
                     "shadow-sm",
                 ].join(" ")}
                 style={{ backgroundColor: backgroundHex, color: textHex }}
-                aria-label={`Preview area with text color ${textHex} on background ${backgroundHex}`}
             >
-                <p className="text-xl font-semibold tracking-tight sm:text-2xl">
+                <h3 className="text-xl font-semibold tracking-tight sm:text-2xl">
                     This is a live preview of large text
-                </p>
+                </h3>
                 <p className="mt-2 text-base sm:text-lg">
                     This is a live preview of normal text
                 </p>

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -52,8 +52,6 @@ export default function StatusBadge({
                 border,
                 className,
             ].join(" ")}
-            // Helpful native tooltip, especially when truncated in tight layouts
-            title={label}
         >
             <img
                 src={icon}


### PR DESCRIPTION
- change `h3` to `h2` to stop skip from `h1` to `h3`
- add `h3` around 'This is a live preview of large text'
- remove 4 X redundant title text from results section